### PR TITLE
Revert "chore(deps): update curlimages/curl docker tag to v8.1.2"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM curlimages/curl:8.1.2 AS curlbase
+FROM curlimages/curl:8.00.1 AS curlbase
 WORKDIR /home/curl_user
 
 FROM curlbase AS gping


### PR DESCRIPTION
This reverts commit 1068ce63512bf1794d8645b403c3f8d297a88ce8.